### PR TITLE
Fix markdown tables overflowing on deployed site

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -81,7 +81,6 @@ blockquote {
 
 table {
   width: 100%;
-  max-width: 100%;
   border: 1px solid var(--bg-tertiary);
   border-radius: var(--border-radius);
 
@@ -89,6 +88,7 @@ table {
     padding: var(--space-sm) var(--space-md);
     text-align: left;
     border-bottom: 1px solid var(--bg-tertiary);
+    word-break: break-word;
   }
 
   th {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -27,6 +27,14 @@ document.addEventListener('DOMContentLoaded', function () {
         }, { passive: true });
     }
 
+    // Wrap bare tables in .table-wrap for horizontal scroll on overflow
+    document.querySelectorAll('.post-content > table').forEach(function (table) {
+        var wrapper = document.createElement('div');
+        wrapper.className = 'table-wrap';
+        table.parentNode.insertBefore(wrapper, table);
+        wrapper.appendChild(table);
+    });
+
     var toggle = document.querySelector('.nav-toggle');
     var links = document.querySelector('.nav-links');
     if (toggle && links) {


### PR DESCRIPTION
## Summary
- Wrap `<table>` elements inside `.post-content` in `.table-wrap` divs via JS, enabling horizontal scroll on overflow
- Remove `max-width: 100%` from `table` so tables can expand naturally inside the scroll wrapper
- Add `word-break: break-word` to `th, td` so long strings (ARNs, URLs) wrap within cells

## Test plan
- [x] Verify tables on [CloudGoat Lambda walkthrough](https://0xdeadbeefjerky.com/posts/cloudgoat-lambda-walkthrough/) render correctly and don't overflow
- [x] Check tables on desktop and mobile viewports
- [x] Confirm code block tables (syntax highlighting line numbers) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)