### PR TITLE
Add GA4 event tracking and SEO improvements

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,6 +1,8 @@
 ---
 layout: default
 permalink: /404.html
+sitemap: false
+noindex: true
 ---
 
 <div class="error-404">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,13 +1,18 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://unpkg.com https://www.googletagmanager.com 'unsafe-inline'; style-src 'self' https://fonts.googleapis.com https://cdnjs.cloudflare.com 'unsafe-inline'; font-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com; img-src 'self' data:; connect-src 'self'; frame-src 'none';">
+{% if page.noindex %}<meta name="robots" content="noindex">{% endif %}
 {% seo %}
 {% include structured-data.html %}
+{% if paginator %}
+{% if paginator.previous_page %}<link rel="prev" href="{{ paginator.previous_page_path | relative_url }}">{% endif %}
+{% if paginator.next_page %}<link rel="next" href="{{ paginator.next_page_path | relative_url }}">{% endif %}
+{% endif %}
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
 <link rel="preconnect" href="https://unpkg.com" crossorigin>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&family=Orbitron:wght@700;900&family=Space+Grotesk:wght@500;600;700&display=swap">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&family=Orbitron:wght@700;900&family=Space+Grotesk:wght@500;600;700&display=swap&subset=latin">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer">
 <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
 <link rel="icon" type="image/png" href="{{ '/assets/img/favicons/favicon.png' | relative_url }}">

--- a/_includes/structured-data.html
+++ b/_includes/structured-data.html
@@ -1,3 +1,31 @@
+{% if page.layout == 'home' or page.url == '/' %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "WebSite",
+      "name": {{ site.title | jsonify }},
+      "url": {{ site.url | jsonify }},
+      "description": {{ site.description | jsonify }},
+      "potentialAction": {
+        "@type": "SearchAction",
+        "target": "{{ site.url }}/?s={search_term_string}",
+        "query-input": "required name=search_term_string"
+      }
+    },
+    {
+      "@type": "Person",
+      "name": {{ site.social.name | jsonify }},
+      "url": {{ site.url | jsonify }}
+      {%- if site.social.links.size > 0 %},
+      "sameAs": {{ site.social.links | jsonify }}
+      {%- endif %}
+    }
+  ]
+}
+</script>
+{% endif %}
 {% if page.layout == 'post' %}
 {% assign sd_words = page.content | number_of_words %}
 {% assign sd_minutes = sd_words | divided_by: 200 %}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,4 +1,10 @@
-// Nav toggle
+// GA4 event helper — no-ops when analytics isn't loaded
+function gaEvent(name, params) {
+    if (typeof gtag === 'function') {
+        gtag('event', name, params || {});
+    }
+}
+
 document.addEventListener('DOMContentLoaded', function () {
     function trapFocus(modal) {
         var focusable = modal.querySelectorAll('button, input, a, [tabindex]:not([tabindex="-1"])');
@@ -101,6 +107,7 @@ document.addEventListener('DOMContentLoaded', function () {
             if (!code) return;
             var text = code.innerText;
             navigator.clipboard.writeText(text).then(function () {
+                gaEvent('code_copy', { code_length: text.length });
                 btn.textContent = 'Copied!';
                 btn.classList.add('copied');
                 setTimeout(function () {
@@ -136,6 +143,9 @@ document.addEventListener('DOMContentLoaded', function () {
                     a.href = '#' + h.id;
                     a.textContent = h.textContent;
                     li.appendChild(a);
+                    a.addEventListener('click', function () {
+                        gaEvent('toc_click', { heading: h.textContent });
+                    });
                     if (h.tagName === 'H3') {
                         li.style.paddingLeft = '1rem';
                     }
@@ -185,10 +195,11 @@ document.addEventListener('DOMContentLoaded', function () {
         updateActiveToc();
     }
 
-    // Reading progress bar
+    // Reading progress bar + scroll depth tracking
     var progressBar = document.getElementById('reading-progress');
     if (progressBar) {
         var article = document.querySelector('.post-content');
+        var depthMarks = {};
         function updateProgress() {
             if (!article) return;
             var articleTop = article.offsetTop;
@@ -197,6 +208,12 @@ document.addEventListener('DOMContentLoaded', function () {
             var pct = Math.min(Math.max((scrolled / articleHeight) * 100, 0), 100);
             progressBar.style.width = pct + '%';
             progressBar.setAttribute('aria-valuenow', Math.round(pct));
+            [25, 50, 75, 100].forEach(function (mark) {
+                if (pct >= mark && !depthMarks[mark]) {
+                    depthMarks[mark] = true;
+                    gaEvent('scroll_depth', { percent: mark });
+                }
+            });
         }
         onScroll(updateProgress);
         updateProgress();
@@ -264,7 +281,36 @@ document.addEventListener('DOMContentLoaded', function () {
             limit: 10,
             fuzzy: false
         });
+
+        // Track search queries (debounced)
+        var searchTimer;
+        searchInput.addEventListener('input', function () {
+            clearTimeout(searchTimer);
+            var query = searchInput.value.trim();
+            if (query.length >= 3) {
+                searchTimer = setTimeout(function () {
+                    gaEvent('search', { search_term: query });
+                }, 1000);
+            }
+        });
     }
+
+    // Track external link clicks
+    document.addEventListener('click', function (e) {
+        var link = e.target.closest('a[href]');
+        if (!link) return;
+        var href = link.getAttribute('href');
+        if (href && href.indexOf('http') === 0 && link.hostname !== location.hostname) {
+            gaEvent('outbound_click', { url: href });
+        }
+    });
+
+    // Track series navigation clicks
+    document.querySelectorAll('.series-nav a').forEach(function (link) {
+        link.addEventListener('click', function () {
+            gaEvent('series_nav_click', { url: link.getAttribute('href') });
+        });
+    });
 
     // Scroll fade-in animation
     if ('IntersectionObserver' in window) {


### PR DESCRIPTION
## Summary
- **GA4 custom events**: Track code block copies, ToC clicks, scroll depth (25/50/75/100%), search queries (debounced), outbound link clicks, and series navigation clicks via a lightweight `gaEvent()` helper that no-ops when analytics isn't loaded
- **Homepage structured data**: Added `WebSite` schema with `SearchAction` (enables sitelinks searchbox eligibility) and `Person` schema with `sameAs` social links (supports author knowledge panel)
- **SEO hygiene**: Added `noindex` + `sitemap: false` on 404 page, `rel="prev"`/`rel="next"` on paginated pages, and Google Fonts latin subsetting for reduced payload

## Test plan
- [x] Verify site builds cleanly (`bundle exec jekyll build`)
- [x] Check 404 page source has `<meta name="robots" content="noindex">`
- [x] Validate homepage JSON-LD at https://search.google.com/test/rich-results
- [x] Confirm `rel="prev"`/`rel="next"` appear in `<head>` on paginated pages
- [x] Open browser console on a post page, verify `gaEvent` calls fire on scroll, code copy, ToC click
- [x] Confirm no JS errors on pages without analytics (non-production)

🤖 Generated with [Claude Code](https://claude.com/claude-code)